### PR TITLE
Added default notification settings

### DIFF
--- a/whistle/managers.py
+++ b/whistle/managers.py
@@ -112,8 +112,9 @@ class NotificationManager(object):
             # user event setting
             return notification_settings['events'][channel][event_identifier]
         except (KeyError, TypeError):
-            # event enabled by default
-            return True
+            # default notification setting (enabled by default if missing)
+            default_settings = whistle_settings.DEFAULT_NOTIFICATIONS
+            return default_settings.get('events', {}).get(channel, {}).get(event_identifier, True)
 
     def notify(self, recipient, event, actor=None, object=None, target=None, details=''):
         if not recipient.is_active:

--- a/whistle/settings.py
+++ b/whistle/settings.py
@@ -15,6 +15,7 @@ SIGNING_KEY = getattr(settings, 'WHISTLE_SIGNING_KEY', settings.SECRET_KEY)
 SIGNING_SALT = getattr(settings, 'WHISTLE_SIGNING_SALT', 'whistle')
 AUTH_USER_MODEL = getattr(settings, 'WHISTLE_AUTH_USER_MODEL', settings.AUTH_USER_MODEL)
 OLD_THRESHOLD = getattr(settings, 'WHISTLE_OLD_THRESHOLD', None)
+DEFAULT_NOTIFICATIONS = getattr(settings, 'WHISTLE_DEFAULT_NOTIFICATIONS', {})
 
 if 'push' in CHANNELS and 'fcm_django' not in settings.INSTALLED_APPS:
     raise ValueError('fcm_django is required for push notifications. Either install the app or remove push channel from whistle channels')


### PR DESCRIPTION
Fallback to `whistle_settings.DEFAULT_NOTIFICATIONS` for missing user notification settings instead of always returning True. Now, you can disable notification by default in your default notification settings.